### PR TITLE
Fix Metal being forced after courses

### DIFF
--- a/Scripts/Branches.lua
+++ b/Scripts/Branches.lua
@@ -22,10 +22,6 @@ end
 
 function EvaluationNextScreen()
 
-	if GAMESTATE:IsCourseMode() then
-		GAMESTATE:ApplyGameCommand('mod,metal');
-	end
-
 	if GetPref('EventMode') then return SongSelectionScreen() end
 	if IsTimedSet() then
 		if Clock( TimedSet.End ) < 0 then 


### PR DESCRIPTION
Should patch my issue #6. No clue why this was even thought about. We don't need Metal in a case where certain gameplay Lua asks for Scalable, or heck, you could be playing a regular course that doesn't force a noteskin to be used, so I removed the problematic code entirely.