### PR TITLE
Fix measure display crash

### DIFF
--- a/Scripts/Mods.lua
+++ b/Scripts/Mods.lua
@@ -453,7 +453,9 @@ function UpdateMeasureText(pn)
 				str = str .. '/' .. math.max(math.floor((k[k[0]][2] - z[table.getn(z)][1])/4),str) -- If current stream is longer than recorded, use current length.
 			end
 		end end
-		measureText[pn]:settext(str)
+		if measureText[pn] then
+			measureText[pn]:settext(str)
+		end
 	end
 end
 


### PR DESCRIPTION
UpdateMeasureText runs at least once before MeasureText() can define the table, so make sure to check if the table exists before setting text